### PR TITLE
Add support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false # Use container-based infrastructure
 python:
   - "2.7"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
-python:
-  - "2.7"
+matrix:
+  fast_finish: true
+  include:
+    - python: "2.7"
+    - python: "3.7"
+      dist: xenial
 install:
   - pip install nose
   - pip install coveralls

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,5 +1,6 @@
 import csv
 import os
+import sys
 from os.path import dirname, abspath
 
 from batlog2csv import Batlog2Csv
@@ -11,8 +12,12 @@ baseDir = dirname(abspath(__file__)) + os.path.sep
 def test_that_standard_log_is_parsed_correctly():
     table = get_csv(baseDir + "/data/default.dat")
 
-    header = table.next()
-    row = table.next()
+    if sys.version_info.major >= 3:
+        header = next(table)
+        row = next(table)
+    else:
+        header = table.next()
+        row = table.next()
 
     check_header(header)
     assert row[0] == "2012-08-14 10:41:46"
@@ -25,8 +30,12 @@ def test_that_standard_log_is_parsed_correctly():
 def test_that_wrongly_ordered_log_is_parsed_correctly():
     table = get_csv(baseDir + "/data/wrongorder.dat")
 
-    header = table.next()
-    row = table.next()
+    if sys.version_info.major >= 3:
+        header = next(table)
+        row = next(table)
+    else:
+        header = table.next()
+        row = table.next()
 
     check_header(header)
     assert row[0] == "2014-08-07 00:15:00"


### PR DESCRIPTION
Same as https://github.com/pietvandongen/batlog2csv/pull/9 but for this fork.

---

The script already works with Python 3 and produces the same output as with Python 2.

The tests needed a small update, and Xenial is required to test on Python 3.7.